### PR TITLE
Addresses issues at startup with joystick/xbox controllers

### DIFF
--- a/containers/examples/Dockerfile
+++ b/containers/examples/Dockerfile
@@ -98,7 +98,7 @@ RUN echo "source ${NDDSHOME}/resource/scripts/rtisetenv_*.bash" >> /root/.bashrc
 
 WORKDIR /root
 
-RUN git clone --recurse-submodule https://github.com/rticommunity/rticonnextdds-medtech-reference-architecture.git medtech_ra 
+RUN git clone -b examples --recurse-submodule https://github.com/rticommunity/rticonnextdds-medtech-reference-architecture.git medtech_ra
 WORKDIR /root/medtech_ra/modules/01-operating-room
 
 # Copy additional source files

--- a/examples/joystick_controller/joystick_controller.py
+++ b/examples/joystick_controller/joystick_controller.py
@@ -203,7 +203,10 @@ class JoystickApp:
 
         threading.Thread(target=self.event_loop.run_forever, daemon=True).start()
 
-        joystick_ok, _ = await asyncio.gather( self.joystick_setup(), self.connext_setup(), return_exceptions=True )
+        joystick_ok, connext_ok = await asyncio.gather(self.joystick_setup(), self.connext_setup(), return_exceptions=True)
+        if isinstance(connext_ok, Exception):
+            print(f"Connext setup failed: {connext_ok}")
+            return
         if not joystick_ok:
             print("Joystick setup failed, exiting.")
             return

--- a/examples/lss_robot/lss_robot_app.py
+++ b/examples/lss_robot/lss_robot_app.py
@@ -79,6 +79,7 @@ class RobotApp:
             self.servolist[i].move(0) # go to initial position
 
         print("Robot hardware setup complete.")
+        return True
 
 
     async def connext_setup(self):
@@ -239,7 +240,13 @@ class RobotApp:
         threading.Thread(target=self.event_loop.run_forever, daemon=True).start()
 
         # setup robot hardware and connext in parallel, as they are independent and can save time - the robot setup can take a while as it resets and initializes the servos, so doing this in parallel with the connext setup allows us to be ready to receive commands as soon as possible. The connext setup is mostly just creating entities and doesn't involve any waiting, so it will be ready very quickly.
-        await asyncio.gather( self.robot_setup(), self.connext_setup() )
+        robot_ok, connext_ok = await asyncio.gather(self.robot_setup(), self.connext_setup(), return_exceptions=True)
+        if isinstance(connext_ok, Exception):
+            print(f"Connext setup failed: {connext_ok}")
+            return
+        if not robot_ok:
+            print("Robot setup failed, exiting.")
+            return
 
         # Start heartbeat task - this will run until the application is shutdown, at which point the stop_event will be set and the task will exit its loop and complete
         hb_task = asyncio.create_task(self.write_hb(self.hb_writer))

--- a/examples/xbox_controller/xbox_controller.py
+++ b/examples/xbox_controller/xbox_controller.py
@@ -274,7 +274,10 @@ class JoystickApp:
 
         threading.Thread(target=self.event_loop.run_forever, daemon=True).start()
 
-        joystick_ok, _ = await asyncio.gather( self.joystick_setup(), self.connext_setup(), return_exceptions=True )
+        joystick_ok, connext_ok = await asyncio.gather(self.joystick_setup(), self.connext_setup(), return_exceptions=True)
+        if isinstance(connext_ok, Exception):
+            print(f"Connext setup failed: {connext_ok}")
+            return
         if not joystick_ok:
             print("Joystick setup failed, exiting.")
             return


### PR DESCRIPTION
The docker script is pulling the main branch, which doesn't have the changes to the DdsUtils.py script for the modules/01-operating-room that the examples branch does. So the Connext setup routine fails with:

module 'DdsUtils' has no attribute 'arm_controller_dp_fqn'

I've added a change to the docker script to ensure that the correct branch is pulled, and added additional guard code to print out failures when configuring Connext where relevant.

Changes:
Added guard code around the async hardware/Connext setup. 
Changed Dockerfile to pull from examples branch